### PR TITLE
Change golangci-lint installation command in Dockerfile 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -28,7 +28,7 @@ RUN echo "node:node"|chpasswd
 
 RUN ARCH=$(uname -m); \
     if [ $ARCH = 'aarch64' ]; then \
-        ARCH='arm64'; \
+    ARCH='arm64'; \
     fi && \
     echo "https://github.com/neovim/neovim/releases/latest/download/nvim-linux-$ARCH.appimage"; \
     curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-$ARCH.appimage; \
@@ -41,9 +41,9 @@ RUN ARCH=$(uname -m); \
 
 RUN ARCH=$(uname -m); \
     if [ $ARCH = 'aarch64' ]; then \
-        ARCH='arm64'; \
+    ARCH='arm64'; \
     elif [ $ARCH = 'x86_64' ]; then \
-        ARCH='amd64'; \
+    ARCH='amd64'; \
     fi && \
     wget https://go.dev/dl/go1.21.6.linux-$ARCH.tar.gz \
     && tar -C /usr/local -xzf go1.21.6.linux-$ARCH.tar.gz \
@@ -75,7 +75,9 @@ ENV PATH="${PATH}:/opt/nvim"
 RUN mkdir -p ~/.config/nvim:wget; \
     git clone https://github.com/corigne/dot-neovim.git .config/nvim;
 
-RUN go install golang.org/x/tools/gopls@latest \
-    && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+RUN go install golang.org/x/tools/gopls@latest
+
+# install golangci-lint
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.63.4
 
 WORKDIR /workspace

--- a/backend/internal/services/api/impl.go
+++ b/backend/internal/services/api/impl.go
@@ -60,7 +60,7 @@ func (t *OpenTutor) CreateUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusCreated)
-	json.NewEncoder(w).Encode(map[string]string{
+	_ = json.NewEncoder(w).Encode(map[string]string{
 		"userId": userId,
 	})
 }
@@ -159,7 +159,7 @@ func (t *OpenTutor) GetUserById(w http.ResponseWriter, r *http.Request, userId o
 	}
 
 	w.WriteHeader(http.StatusOK)
-	json.NewEncoder(w).Encode(user)
+	_ = json.NewEncoder(w).Encode(user)
 }
 
 func (t *OpenTutor) UpdateUserById(w http.ResponseWriter, r *http.Request, userId openapi_types.UUID) {


### PR DESCRIPTION
... so the version we get is compatible with 1.23 (current version for our app). Allows linting locally. Also fixed the last of the linter errors.
